### PR TITLE
feat: add nix overlay to flake outputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,6 +5,11 @@
   };
 
   outputs = { self, nixpkgs, flake-utils }:
+    {
+      overlay = final: prev: {
+        krewfile = self.packages.${prev.system}.default;
+      };
+    } //
     flake-utils.lib.eachDefaultSystem (system:
       let
         name = "krewfile";


### PR DESCRIPTION
you can do this cool stuff with it: https://github.com/breuerfelix/dotfiles/blob/b2d882405a9554a275f9a6f68426d628074e4039/flake.nix#L59

Signed-off-by: Felix Breuer <fbreuer@pm.me>