### PR TITLE
✨ Add hm-module

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,40 @@ This repo contains a [`flake.nix`](flake.nix) file which you can use for example
 ```shell
 nix run github:brumhard/krewfile# -- -help
 ```
+
+**Using home-manager module**
+
+If you using flakes to manage your system, add the `krewfile` input as follows:
+
+```nix
+# ...
+inputs.krewfile = {
+  url = "github:brumhard/krewfile";
+  inputs.nixpkgs.follows = "nixpkgs";
+};
+```
+
+You can now access the module via `inputs.krewfile.homeManagerModules.krewfile`.
+Assuming a setup with properly configured imports via `home-manager.extraSpecialArgs`, the module can be imported and configured as shown below:
+
+```nix
+{ inputs, pkgs, ... }: {
+  imports [
+    # ...
+    inputs.krewfile.homeManagerModules.krewfile
+  ];
+
+  programs.krewfile = {
+    enable = true;
+    krewPackage = pkgs.krew;
+    plugins = [
+      "explore"
+      "modify-secret"
+      "neat"
+      "oidc-login"
+      "pv-migrate"
+      "stern"
+    ];
+  };
+}
+```

--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,11 @@
       overlay = final: prev: {
         krewfile = self.packages.${prev.system}.default;
       };
+
+      homeManagerModules = {
+        default = self.homeManagerModules.krewfile;
+        krewfile = import ./hm-module.nix self;
+      };
     }
     // flake-utils.lib.eachDefaultSystem (system: let
       name = "krewfile";

--- a/hm-module.nix
+++ b/hm-module.nix
@@ -47,8 +47,6 @@ in
     home.sessionVariables.PATH = "$HOME/.krew/bin:$PATH";
 
     home.activation.krew = hm.dag.entryAfter [ "writeBoundary" ] ''
-      PATH="$HOME/.krew/bin:$PATH"
-      run ${cfg.krewPackage}/bin/${cfg.krewPackage.pname} update
       run ${finalPackage}/bin/${finalPackage.pname} \
         -command ${cfg.krewPackage}/bin/${cfg.krewPackage.pname} \
         -file ${krewfileContent} ${args}

--- a/hm-module.nix
+++ b/hm-module.nix
@@ -12,38 +12,47 @@ let
   cfg = config.programs.krewfile;
   finalPackage = self.packages.${pkgs.system}.krewfile;
   krewfileContent = pkgs.writeText "krewfile" (concatStringsSep "\n" cfg.plugins);
+  args = if cfg.upgrade then "-upgrade" else "";
 in
 {
   options.programs.krewfile = {
     enable = mkEnableOption "krewfile";
 
-    installKrew = mkEnableOption "installKrew";
-
     krewPackage = mkOption {
       type = types.package;
       default = pkgs.krew;
       defaultText = literalExpression "pkgs.krew";
-      description = ''
-        Krew package to install.
-        Only relevant if `programs.krewfile.installKrew` is enabled.
-      '';
+      description = "Krew package to install.";
     };
 
     plugins = mkOption {
       type = with types; listOf str;
       default = [ ];
-      description = "List of plugins to be written to the krewfile.";
+      defaultText = literalExpression "[ "edit-status" ]";
+      description = "List of plugins to be installed.";
+    };
+
+    upgrade = mkOption {
+      type = types.bool;
+      default = false;
+      defaultText = literalExpression "false";
+      description = "Enable auto update of plugins.";
     };
   };
 
   config = mkIf cfg.enable {
 
-    home.packages = ([ finalPackage ] ++ optionals cfg.installKrew [ cfg.krewPackage ]);
+    home.packages = [ finalPackage cfg.krewPackage ];
+
+    home.sessionVariables.PATH = "$HOME/.krew/bin:$PATH";
 
     home.activation.krew = hm.dag.entryAfter [ "writeBoundary" ] ''
+      echo $PATH
+      PATH="$HOME/.krew/bin:$PATH"
+      run ${cfg.krewPackage}/bin/${cfg.krewPackage.pname} update
       run ${finalPackage}/bin/${finalPackage.pname} \
         -command ${cfg.krewPackage}/bin/${cfg.krewPackage.pname} \
-        -file ${krewfileContent} -upgrade
+        -file ${krewfileContent} ${args}
     '';
   };
 }

--- a/hm-module.nix
+++ b/hm-module.nix
@@ -1,0 +1,18 @@
+self:
+{ config, lib, pkgs, ... }:
+with lib;
+let
+  cfg = config.programs.krewfile;
+  finalPackage = self.packages.${pkgs.system}.krewfile;
+in
+{
+  options.programs.krewfile = {
+    enable = mkEnableOption "krewfile";
+    installKrew = mkEnableOption "installKrew";
+  };
+  config = mkIf cfg.enable {
+    home.packages = ([
+      finalPackage
+    ] ++ optionals cfg.installKrew [ pkgs.krew ]);
+  };
+}

--- a/hm-module.nix
+++ b/hm-module.nix
@@ -1,18 +1,47 @@
 self:
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
 with lib;
+
 let
   cfg = config.programs.krewfile;
   finalPackage = self.packages.${pkgs.system}.krewfile;
+  krewfile = pkgs.writeText "krewfile" ''
+    ${cfg.plugins}
+  '';
 in
 {
   options.programs.krewfile = {
     enable = mkEnableOption "krewfile";
+
     installKrew = mkEnableOption "installKrew";
+
+    krewPackage = mkOption {
+      type = types.package;
+      default = pkgs.krew;
+      defaultText = literalExpression "pkgs.krew";
+      description = "krew package to install.";
+    };
+
+    plugins = mkOption { type = with types; listOf str; };
   };
+
   config = mkIf cfg.enable {
-    home.packages = ([
-      finalPackage
-    ] ++ optionals cfg.installKrew [ pkgs.krew ]);
+
+    home.packages = ([ finalPackage ] ++ optionals cfg.installKrew [ cfg.krewPackage ]);
+
+    home.file.".krewfile".text = ''
+      ${concatStringsSep "\n" cfg.plugins}
+    '';
+
+    home.activation.krew = hm.dag.entryAfter [ "writeBoundary" ] ''
+      PATH=$PATH:${cfg.krewPackage}/bin
+      run ${finalPackage}/bin/${finalPackage.pname}
+    '';
   };
 }

--- a/hm-module.nix
+++ b/hm-module.nix
@@ -56,7 +56,7 @@ in
 
     home.activation.krew = hm.dag.entryAfter [ "writeBoundary" ] ''
       PATH=$PATH:${cfg.krewPackage}/bin
-      run ${finalPackage}/bin/${finalPackage.pname}
+      run ${finalPackage}/bin/${finalPackage.pname} -file ${cfg.path}
     '';
   };
 }

--- a/hm-module.nix
+++ b/hm-module.nix
@@ -47,7 +47,6 @@ in
     home.sessionVariables.PATH = "$HOME/.krew/bin:$PATH";
 
     home.activation.krew = hm.dag.entryAfter [ "writeBoundary" ] ''
-      echo $PATH
       PATH="$HOME/.krew/bin:$PATH"
       run ${cfg.krewPackage}/bin/${cfg.krewPackage.pname} update
       run ${finalPackage}/bin/${finalPackage.pname} \

--- a/hm-module.nix
+++ b/hm-module.nix
@@ -11,9 +11,7 @@ with lib;
 let
   cfg = config.programs.krewfile;
   finalPackage = self.packages.${pkgs.system}.krewfile;
-  krewfile = pkgs.writeText "krewfile" ''
-    ${cfg.plugins}
-  '';
+  krewfileContent = concatStringsSep "\n" cfg.plugins;
 in
 {
   options.programs.krewfile = {
@@ -25,19 +23,36 @@ in
       type = types.package;
       default = pkgs.krew;
       defaultText = literalExpression "pkgs.krew";
-      description = "krew package to install.";
+      description = ''
+        Krew package to install.
+        Only relevant if `programs.krewfile.installKrew` is enabled.
+      '';
     };
 
-    plugins = mkOption { type = with types; listOf str; };
+    path = mkOption {
+      type = types.string;
+      default = ".krewfile";
+      defaultText = literalExpression ".krewfile";
+      description = ''
+        Specify the path where the `krewfile` is written.
+        This is relative to the home directory.
+      '';
+    };
+
+    plugins = mkOption {
+      type = with types; listOf str;
+      default = [ ];
+      description = "List of plugins to be written to the krewfile.";
+    };
   };
 
   config = mkIf cfg.enable {
 
     home.packages = ([ finalPackage ] ++ optionals cfg.installKrew [ cfg.krewPackage ]);
 
-    home.file.".krewfile".text = ''
-      ${concatStringsSep "\n" cfg.plugins}
-    '';
+    home.file = {
+      ${cfg.path}.text = krewfileContent;
+    };
 
     home.activation.krew = hm.dag.entryAfter [ "writeBoundary" ] ''
       PATH=$PATH:${cfg.krewPackage}/bin


### PR DESCRIPTION
Adds a hm-module to configure krewfile.

Basic capabilities:
- install `krewfile` & `krew`
- configure which `package` of `krew` to install
- list of `plugins` to install
- configure `PATH` for `kubectl` to find `plugins` (need to start new terminal session) 