### PR TITLE
fix: nix package dependencies

### DIFF
--- a/hm-module.nix
+++ b/hm-module.nix
@@ -43,10 +43,11 @@ in
   config = mkIf cfg.enable {
 
     home.packages = [ finalPackage cfg.krewPackage ];
+    home.extraActivationPath = [ pkgs.git ];
 
     home.sessionVariables.PATH = "$HOME/.krew/bin:$PATH";
 
-    home.activation.krew = hm.dag.entryAfter [ "writeBoundary" ] ''
+    home.activation.krew = hm.dag.entryAfter [ "installPackages" ] ''
       run ${finalPackage}/bin/${finalPackage.pname} \
         -command ${cfg.krewPackage}/bin/${cfg.krewPackage.pname} \
         -file ${krewfileContent} ${args}


### PR DESCRIPTION
The current `hm-modules.nix` files won't work on raw NixOS filesystems, because `git` is missing during build phase - and `krew` depends on it (and for some reason, default package doesn't provide it). This PR adds it, and ensures it will be available during activation.