### PR TITLE
Add support for krew indexes

### DIFF
--- a/hm-module.nix
+++ b/hm-module.nix
@@ -28,6 +28,12 @@ in
       description = "Krew package to install.";
     };
 
+    krewRoot = mkOption {
+      type = types.path;
+      default = "${config.home.homeDirectory}/.krew";
+      description = "Path where all krew-related files will be installed and stored.";
+    };
+
     plugins = mkOption {
       type = with types; listOf str;
       default = [ ];
@@ -54,9 +60,12 @@ in
     home.packages = [ finalPackage cfg.krewPackage ];
     home.extraActivationPath = [ pkgs.git ];
 
-    home.sessionVariables.PATH = "$HOME/.krew/bin:$PATH";
+    home.sessionVariables.KREW_ROOT = "${cfg.krewRoot}";
+    home.sessionPath = [ "${cfg.krewRoot}/bin" ];
 
     home.activation.krew = hm.dag.entryAfter [ "installPackages" ] ''
+      KREW_ROOT="${cfg.krewRoot}";
+
       run ${finalPackage}/bin/${finalPackage.pname} \
         -command ${cfg.krewPackage}/bin/${cfg.krewPackage.pname} \
         -file ${krewfileContent} ${args}

--- a/main_test.go
+++ b/main_test.go
@@ -5,40 +5,136 @@ import (
 	"testing"
 )
 
-func Test_readBytesToPluginMap(t *testing.T) {
+func Test_readPluginsFromKrew(t *testing.T) {
 	tests := []struct {
-		name string
-		in   string
-		want map[string]struct{}
+		name          string
+		input         string
+		wantPluginMap PluginMap
 	}{
 		{
-			name: "plain",
-			in: `
-plugin1
-plugin2
+			name: "krew index output",
+			input: `
+PLUGIN             VERSION
+node-shell         v1.10.1
+resource-capacity  v0.8.0
 `,
-			want: map[string]struct{}{
-				"plugin1": {},
-				"plugin2": {},
-			},
-		},
-		{
-			name: "with_comments",
-			in: `
-# comment
-plugin1 # comment after plugin
-# disabled-plugin
-	# empty line but with whitespace
-`,
-			want: map[string]struct{}{
-				"plugin1": {},
+			wantPluginMap: PluginMap{
+				"node-shell":        struct{}{},
+				"resource-capacity": struct{}{},
 			},
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := readBytesToPluginMap([]byte(tt.in)); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("readBytesToPluginMap() = %v, want %v", got, tt.want)
+			if got := readPluginsFromKrew([]byte(tt.input)); !reflect.DeepEqual(got, tt.wantPluginMap) {
+				t.Errorf("readIndexesFromKrew() = %v, want %v", got, tt.wantPluginMap)
+			}
+		})
+	}
+}
+
+func Test_readIndexesFromKrew(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		wantIndexMap IndexMap
+	}{
+		{
+			name: "krew index output",
+			input: `
+INDEX     URL
+default   https://github.com/kubernetes-sigs/krew-index.git
+netshoot  https://github.com/nilic/kubectl-netshoot.git
+`,
+			wantIndexMap: IndexMap{
+				"default":  "https://github.com/kubernetes-sigs/krew-index.git",
+				"netshoot": "https://github.com/nilic/kubectl-netshoot.git",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := readIndexesFromKrew([]byte(tt.input)); !reflect.DeepEqual(got, tt.wantIndexMap) {
+				t.Errorf("readIndexesFromKrew() = %v, want %v", got, tt.wantIndexMap)
+			}
+		})
+	}
+}
+
+func Test_readKrewfile(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		wantPluginMap PluginMap
+		wantIndexMap  IndexMap
+		wantErr       error
+	}{
+		{
+			name: "plain",
+			input: `
+index index1 https://myindex1.url.home.arpa/
+index index2 https://myindex2.url.home.arpa/
+
+index1/plugin1
+plugin2
+      `,
+			wantPluginMap: PluginMap{"index1/plugin1": {}, "plugin2": {}},
+			wantIndexMap: IndexMap{
+				"index1": "https://myindex1.url.home.arpa/",
+				"index2": "https://myindex2.url.home.arpa/",
+			},
+			wantErr: nil,
+		}, {
+			name: "with comments",
+			input: `
+# index comment
+index index1 https://myindex1.url.home.arpa/ # comment after index
+# index disabled-index https://myindex2.url.home.arpa/
+
+plugin1
+# disabled-plugin
+  # empty line but with whitespace
+      `,
+			wantPluginMap: PluginMap{"plugin1": {}},
+			wantIndexMap: IndexMap{
+				"index1": "https://myindex1.url.home.arpa/",
+			},
+			wantErr: nil,
+		}, {
+			name: "with error",
+			input: `
+invalid line
+      `,
+			wantPluginMap: nil,
+			wantIndexMap:  nil,
+			wantErr:       InvalidKrewfileLineError{line: "invalid line"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotPluginMap, gotIndexMap, gotErr := readKrewfile([]byte(tt.input))
+
+			if !reflect.DeepEqual(gotPluginMap, tt.wantPluginMap) {
+				t.Errorf("readKrewfile()/PluginMap = %v, want %v", gotPluginMap, tt.wantPluginMap)
+			}
+
+			if !reflect.DeepEqual(gotIndexMap, tt.wantIndexMap) {
+				t.Errorf("readKrewfile()/IndexMap = %v, want %v", gotIndexMap, tt.wantIndexMap)
+			}
+
+			if gotErr == nil {
+				if tt.wantErr != nil {
+					t.Errorf("readKrewfile()/err = %v, want %v", gotErr, tt.wantErr)
+				}
+
+				return
+			}
+
+			if gotErr.Error() != tt.wantErr.Error() {
+				t.Errorf("readKrewfile()/err = %q, want %q", gotErr, tt.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
Krew has built-in [external indexes support](https://krew.sigs.k8s.io/docs/user-guide/custom-indexes/). It would be nice, if krewfile support that :-). This PR adds a new syntax, using `index` keyword, while maintaining backwards compatibility. 

Example krewfile:
```
index netshoot https://github.com/nilic/kubectl-netshoot.git

netshoot/netshoot
modify-secret
node-shell
resource-capacity
```

Also as I bonus I added `-dry-run` flag, which may be useful for testing.