### PR TITLE
fix: krewRoot not working with nix home-manager

### DIFF
--- a/hm-module.nix
+++ b/hm-module.nix
@@ -64,7 +64,7 @@ in
     home.sessionPath = [ "${cfg.krewRoot}/bin" ];
 
     home.activation.krew = hm.dag.entryAfter [ "installPackages" ] ''
-      KREW_ROOT="${cfg.krewRoot}";
+      export KREW_ROOT="${cfg.krewRoot}";
 
       run ${finalPackage}/bin/${finalPackage.pname} \
         -command ${cfg.krewPackage}/bin/${cfg.krewPackage.pname} \


### PR DESCRIPTION
I am using the nix home-manager module for krewfile.
I have configured it as follows, but regardless of what value I set for krewRoot, the default "~/.krew" is always used.

```nix
programs.krewfile = {
  enable = true;
  krewPackage = pkgs.krew;
  krewRoot = "${config.home.homeDirectory}/.local/krew";
  upgrade = true;
  plugins = [
    "auth-proxy"
    "blame"
    "df-pv"
    # "insider"
    "ktop"
    "neat"
    "resource-capacity"
    "sniff"
  ];
};
```

To address this issue, I changed the KREW_ROOT variable inside the script so that it is read from an environment variable.